### PR TITLE
Add: Funcionalidade das Capas Ilustres

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -258,7 +258,7 @@ $amarelo: #ffff00;
             align-items: center;
             justify-content: center;
             width: 85vw;
-            height: 20vw;
+            height: 30vw;
 
             button {
                 display: none !important;
@@ -527,6 +527,8 @@ $amarelo: #ffff00;
             border: 1px solid rgba(255, 255, 255, 0.18);
             margin-bottom: 1rem;
             padding: 0.5rem;
+            margin-left: 0.5rem;
+            margin-right: 0.5rem;
         }
 
         #steps-indicator {
@@ -633,6 +635,7 @@ $amarelo: #ffff00;
                 }
 
                 min-height: 25vh;
+                height: 60vw;
 
                 div .cardColor {
                     margin: 0;

--- a/src/pages/admin/createColor/index.js
+++ b/src/pages/admin/createColor/index.js
@@ -20,11 +20,20 @@ export default function CreateColor() {
         models: [],
         categories: [],
     });
+    const [newIlustresData, setNewIlustresData] = useState({
+        aditionalPrice: 0,
+        preSelectedLineColor: '',
+        preSelectedElasticColor: '',
+        preSelectedSpiralColor: '',
+    });
 
     const [colors, setColors] = useState([]);
     const [selectedModels, setSelectedModels] = useState([]);
     const [selectedCategories, setSelectedCategories] = useState([]);
+    const [selectedSizes, setSelectedSizes] = useState([]);
     const [imageUrl, setImageUrl] = useState('');
+    const [isIlustres, setIsIlustres] = useState(false);
+    const [displayIlustresData, setDisplayIlustresData] = useState('none');
     const [dataKeys, setDataKeys] = useState([]);
     const [selectItemToDelete, setSelectItemToDelete] = useState('');
 
@@ -37,6 +46,12 @@ export default function CreateColor() {
             colorCode: colorData.colorCode,
             models: selectedModels,
             categories: selectedCategories,
+            isIlustres: isIlustres,
+            aditionalPrice: Number(newIlustresData.aditionalPrice),
+            availableSizes: selectedSizes,
+            preSelectedLineColor: newIlustresData.preSelectedLineColor,
+            preSelectedElasticColor: newIlustresData.preSelectedElasticColor,
+            preSelectedSpiralColor: newIlustresData.preSelectedSpiralColor,
             image: imageUrl,
         };
 
@@ -52,7 +67,20 @@ export default function CreateColor() {
             image: '',
             models: [],
             categories: [],
+            aditionalPrice: 0,
         });
+        setNewIlustresData({
+            aditionalPrice: 0,
+            availableSizes: [],
+            preSelectedLineColor: '',
+            preSelectedElasticColor: '',
+            preSelectedSpiralColor: '',
+        });
+        setSelectedSizes([]);
+        setSelectedCategories([]);
+        setSelectedModels([]);
+        setImageUrl('');
+        setIsIlustres(false);
 
         alert('Cor inserida com sucesso!');
         window.location.reload();
@@ -134,6 +162,69 @@ export default function CreateColor() {
             .then((snapshot) => {
                 snapshot.ref.getDownloadURL().then((url) => setImageUrl(url));
             });
+    }
+
+    const checkSizes = (event) => {
+        const isChecked = event.target.checked;
+
+        if (isChecked) {
+            setSelectedSizes([...selectedSizes, event.target.value]);
+        } else {
+            let index = selectedSizes.findIndex(
+                (element) => element === event.target.value
+            );
+
+            if (index !== -1) {
+                selectedSizes.splice(index, 1);
+            }
+        }
+    };
+
+    function handleIlustresCoverChange(event) {
+        if (event.target.value === 'sim') {
+            setDisplayIlustresData('flex');
+            setIsIlustres(true);
+        }
+        if (event.target.value === 'nao') {
+            setDisplayIlustresData('none');
+            setIsIlustres(false);
+
+            //zera as infos da Capa ilustres
+            setNewIlustresData({
+                aditionalPrice: 0,
+                preSelectedLineColor: '',
+                preSelectedElasticColor: '',
+                preSelectedSpiralColor: '',
+            });
+
+            //zera o input de preço
+            document.querySelector('#ilustresPrice').value = '0';
+
+            // desmarca todas as checkboxes de tamanho
+            document
+                .querySelectorAll('.availableSizes')
+                .forEach(function (check) {
+                    check.checked = false;
+                });
+
+            setSelectedSizes([]);
+        }
+    }
+
+    function handleNewIlustresChange(event) {
+        const { name, value } = event.target;
+        setNewIlustresData({
+            ...newIlustresData,
+            [name]: value,
+        });
+    }
+
+    function handleSelectItemToIncludeToIlustres(event) {
+        const { name, value } = event.target;
+        setNewIlustresData({
+            ...newIlustresData,
+            [name]: colors[value],
+        });
     }
 
     function handleSelectItemToDelete(event) {
@@ -298,6 +389,168 @@ export default function CreateColor() {
                                 onChange={(event) => checkModel(event)}
                             />
                             <label for='sertao'>Sertão</label>
+                        </div>
+                    </div>
+                </div>
+
+                <div className='checkboxSelector'>
+                    <h3>Capa ILUSTRES?</h3>
+                    <div className='checkboxWrapper'>
+                        <div className='checkbox'>
+                            <input
+                                type='radio'
+                                name='selectedCoverAdd'
+                                id='sim'
+                                value='sim'
+                                onChange={(event) =>
+                                    handleIlustresCoverChange(event)
+                                }
+                            />
+                            <label htmlFor='sim'>Sim</label>
+                        </div>
+                        <div className='checkbox'>
+                            <input
+                                type='radio'
+                                name='selectedCoverAdd'
+                                id='nao'
+                                value='nao'
+                                onChange={(event) =>
+                                    handleIlustresCoverChange(event)
+                                }
+                            />
+                            <label htmlFor='nao'>Nao</label>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    id='ilustresData'
+                    className='checkboxSelector'
+                    style={{ display: displayIlustresData }}
+                >
+                    <h3>Preço Adicional</h3>
+                    <input
+                        type='number'
+                        id='ilustresPrice'
+                        name='aditionalPrice'
+                        placeholder='Preço adicional da capa'
+                        min='0'
+                        onChange={handleNewIlustresChange}
+                    />
+
+                    <h3>Cor da Linha</h3>
+                    <select
+                        onChange={handleSelectItemToIncludeToIlustres}
+                        name='preSelectedLineColor'
+                    >
+                        <option selected disabled>
+                            Selecione a cor
+                        </option>
+
+                        {colors.map((item, index) =>
+                            item.categories.includes('line') ? (
+                                <option value={index} key={index}>
+                                    {item.colorName}
+                                </option>
+                            ) : null
+                        )}
+                    </select>
+
+                    <h3>Cor do Elástico</h3>
+                    <select
+                        onChange={handleSelectItemToIncludeToIlustres}
+                        name='preSelectedElasticColor'
+                    >
+                        <option selected disabled>
+                            Cor do Elástico
+                        </option>
+
+                        {colors.map((item, index) =>
+                            item.categories.includes('elastic') ? (
+                                <option value={index} key={index}>
+                                    {item.colorName}
+                                </option>
+                            ) : null
+                        )}
+                    </select>
+
+                    <h3>Cor da Espiral</h3>
+                    <select
+                        onChange={handleNewIlustresChange}
+                        name='preSelectedSpiralColor'
+                        defaultValue=''
+                    >
+                        <option value=''>Cor do Elástico</option>
+                        <option value='Preto'>Preto</option>
+                        <option value='Branco'>Branco</option>
+                    </select>
+
+                    <h3>Tamanhos Disponíveis</h3>
+                    <div className='checkboxWrapper'>
+                        <div className='checkbox'>
+                            <input
+                                type='checkbox'
+                                name='selectedAvailableSize'
+                                className='availableSizes'
+                                id='A4 - Retrato'
+                                value='A4 - Retrato'
+                                onChange={(event) => checkSizes(event)}
+                            />
+                            <label htmlFor='A4 - Retrato'>A4 - Retrato</label>
+                        </div>
+                        <div className='checkbox'>
+                            <input
+                                type='checkbox'
+                                name='selectedAvailableSize'
+                                className='availableSizes'
+                                id='A4 - Paisagem'
+                                value='A4 - Paisagem'
+                                onChange={(event) => checkSizes(event)}
+                            />
+                            <label htmlFor='A4 - Paisagem'>A4 - Paisagem</label>
+                        </div>
+                        <div className='checkbox'>
+                            <input
+                                type='checkbox'
+                                name='selectedAvailableSize'
+                                className='availableSizes'
+                                id='A5 - Retrato'
+                                value='A5 - Retrato'
+                                onChange={(event) => checkSizes(event)}
+                            />
+                            <label htmlFor='A5 - Retrato'>A5 - Retrato</label>
+                        </div>
+                        <div className='checkbox'>
+                            <input
+                                type='checkbox'
+                                name='selectedAvailableSize'
+                                className='availableSizes'
+                                id='A5 - Paisagem'
+                                value='A5 - Paisagem'
+                                onChange={(event) => checkSizes(event)}
+                            />
+                            <label htmlFor='A5 - Paisagem'>A5 - Paisagem</label>
+                        </div>
+                        <div className='checkbox'>
+                            <input
+                                type='checkbox'
+                                name='selectedAvailableSize'
+                                className='availableSizes'
+                                id='A6 - Retrato'
+                                value='A6 - Retrato'
+                                onChange={(event) => checkSizes(event)}
+                            />
+                            <label htmlFor='A6 - Retrato'>A6 - Retrato</label>
+                        </div>
+                        <div className='checkbox'>
+                            <input
+                                type='checkbox'
+                                name='selectedAvailableSize'
+                                className='availableSizes'
+                                id='A6 - Paisagem'
+                                value='A6 - Paisagem'
+                                onChange={(event) => checkSizes(event)}
+                            />
+                            <label htmlFor='A6 - Paisagem'>A6 - Paisagem</label>
                         </div>
                     </div>
                 </div>

--- a/src/pages/admin/createColor/style.scss
+++ b/src/pages/admin/createColor/style.scss
@@ -65,7 +65,7 @@ main {
 
         }
 
-        input[type=text] {
+        input[type=text], #ilustresPrice{
 
             margin-bottom: 2rem;
             width: 50%;
@@ -147,6 +147,20 @@ main {
 
             }
 
+        }
+
+        #ilustresData{
+            select {
+            
+                    margin: .2rem .2rem;
+                    padding: .7rem 0;
+                    border-radius: 5px;
+                    width: 50%;
+            
+                    border: 1.7px solid #e8e8e8;
+                    outline-color: $orange;
+            
+                }
         }
 
     }
@@ -255,6 +269,11 @@ main {
                 }
     
             }
+            #ilustresData{
+                select, #ilustresPrice {
+                    width: 100%;            
+                    }
+                }   
     
         }
     

--- a/src/pages/create/baiao/index.js
+++ b/src/pages/create/baiao/index.js
@@ -630,7 +630,9 @@ export default function Baiao() {
                         <Slider {...settings}>
                             {dataColors.map((item, index) =>
                                 item.models.includes('baiao') &&
-                                item.categories.includes('cover') ? (
+                                item.categories.includes('cover') &&
+                                // não mostra as capas ilustres, caso seja cadastrada errado, pq nao esta disponivel pro baiao
+                                !item.isIlustres ? (
                                     <div className='cardColor' key={index}>
                                         <label
                                             htmlFor={index}

--- a/src/pages/create/buriti/index.js
+++ b/src/pages/create/buriti/index.js
@@ -471,7 +471,9 @@ export default function Buriti() {
                         <Slider {...settings}>
                             {dataColors.map((item, index) =>
                                 item.models.includes('buriti') &&
-                                item.categories.includes('cover') ? (
+                                item.categories.includes('cover') &&
+                                // não mostra as capas ilustres, caso seja cadastrada errado, pq nao esta disponivel pro buriti
+                                !item.isIlustres ? (
                                     <div className='cardColor' key={index}>
                                         <label
                                             htmlFor={index}

--- a/src/pages/create/carcara/index.js
+++ b/src/pages/create/carcara/index.js
@@ -29,9 +29,13 @@ export default function Carcara() {
     const [checkedBoxes, setCheckedBoxes] = useState(0);
     const [selectedPaperWidth, setSelectedPaperWidth] = useState('');
     const [selectedElasticColor, setSelectedElasticColor] = useState('');
+    const [preSelectedElasticColor, setPreSelectedElasticColor] = useState('');
+    const [displayElasticColorSelection, setDisplayElasticColorSelection] =
+        useState('flex');
     const [selectedSketchFinish, setSelectedSketchFinish] = useState('');
     const [clientNote, setClientNote] = useState('');
     const [sketchbookInfos, setSketchbookInfos] = useState('');
+    const [totalValue, setTotalValue] = useState(0);
     const [displayModal, setDisplayModal] = useState('none');
     const [maxSlides, setMaxSlides] = useState(5);
     const [clicked, setClicked] = useState(5);
@@ -767,11 +771,31 @@ export default function Carcara() {
         // forçando-o a escolher novamente os papel do miolo, garantindo que o preço e o papel escolhidos estarão corretos
         setSketchbookInfos('');
         document.querySelector('.paper').selectedIndex = 0;
+        setTotalValue(0);
     }
 
     function handleSelectedType(event) {
         let position = event.target.value;
         setSketchbookInfos(formatTypes[position]);
+        setTotalValue(formatTypes[position].value);
+
+        // desmarca todas as checkboxes
+        document
+            .querySelectorAll('input[type=checkbox]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+        //"despinta" todas as checkboxes
+        document.querySelectorAll('.coverColorLabel').forEach((label) => {
+            label.style.backgroundColor = 'transparent';
+        });
+        // zera as capas selecionadas, para nao dar problema no calculo do preco se selecionar uma capa ILUSTRES
+        setSelectedColors([]);
+        setCheckedBoxes(0);
+
+        // zera as cores de linha e elastico selecionadas, para caso seja selecionado uma ilustres e o cliente volte para mudar o papel, e
+        // pelas linhas acima as capas sao zeradas, e se uma capa ilustre que tinha sido selecionada é zerada, suas cores (de linha e elastico) predefinidas tambem precisam ser zeradas
+        zerarCoresPreSelecionadas();
     }
 
     function onAuthStateChanged(user) {
@@ -817,7 +841,7 @@ export default function Carcara() {
             id: formatId,
             paperWidth: selectedPaperWidth,
             paper: sketchbookInfos.name,
-            value: sketchbookInfos.value,
+            value: totalValue,
             elasticColor: selectedElasticColor,
             coverColors: selectedColors,
             sketchFinish: selectedSketchFinish,
@@ -866,6 +890,23 @@ export default function Carcara() {
             ]);
 
             setCheckedBoxes(checkedBoxes + 1);
+
+            if (item.isIlustres) {
+                setTotalValue(sketchbookInfos.value + item.aditionalPrice);
+                // define a cor do elastico do sketch e esconde o seletor de cor de elastico se a pre definifa existir (se nao for uma string vazia)
+                if (item.preSelectedElasticColor) {
+                    setDisplayElasticColorSelection('none');
+                    setSelectedElasticColor(item.preSelectedElasticColor);
+                    setPreSelectedElasticColor(item.preSelectedElasticColor);
+                }
+
+                // desmarca todos os radio buttons de cor de elastico
+                document
+                    .querySelectorAll('input[name=selectedElasticColor]')
+                    .forEach(function (check) {
+                        check.checked = false;
+                    });
+            }
         } else {
             const color = item.colorName;
             let index = selectedColors.findIndex(
@@ -876,8 +917,27 @@ export default function Carcara() {
                 selectedColors.splice(index, 1);
                 setCheckedBoxes(checkedBoxes - 1);
             }
+
+            if (item.isIlustres) {
+                setTotalValue(sketchbookInfos.value);
+                zerarCoresPreSelecionadas();
+            }
         }
     };
+
+    function zerarCoresPreSelecionadas() {
+        setSelectedElasticColor('');
+        setPreSelectedElasticColor('');
+
+        setDisplayElasticColorSelection('flex');
+
+        // desmarca todos os radio buttons de cor de elastico
+        document
+            .querySelectorAll('input[name=selectedElasticColor]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+    }
 
     useEffect(() => {
         if (
@@ -1128,12 +1188,15 @@ export default function Carcara() {
 
                     <div className='sliderColors'>
                         <Slider {...settings}>
+                            {/* Mostra todas as capas que nao sao ilustres, que sao deste modelo */}
                             {dataColors.map((item, index) =>
                                 item.models.includes('carcara') &&
-                                item.categories.includes('cover') ? (
+                                item.categories.includes('cover') &&
+                                !item.isIlustres ? (
                                     <div className='cardColor' key={index}>
                                         <label
                                             htmlFor={index}
+                                            className='coverColorLabel'
                                             onClick={(event) =>
                                                 changeColor(event)
                                             }
@@ -1181,6 +1244,77 @@ export default function Carcara() {
                                     </div>
                                 ) : null
                             )}
+                            {/* Mostra as capas ilustres ao final para deixar agrupadas, que sao deste modelo, e que estao disponiveis para o tamanho selecionado */}
+                            {dataColors.map((item, index) =>
+                                item.availableSizes && selectedPaperWidth ? (
+                                    item.models.includes('mandacaru') &&
+                                    item.categories.includes('cover') &&
+                                    item.availableSizes.includes(
+                                        selectedPaperWidth
+                                    ) ? (
+                                        <div className='cardColor' key={index}>
+                                            <label
+                                                htmlFor={index}
+                                                className='coverColorLabel'
+                                                onClick={(event) =>
+                                                    changeColor(event)
+                                                }
+                                            />
+
+                                            {item.image ? (
+                                                <div
+                                                    key={item.id}
+                                                    className='colorBox'
+                                                >
+                                                    <img
+                                                        draggable='false'
+                                                        src={item.image}
+                                                        alt='cor'
+                                                    />
+                                                </div>
+                                            ) : (
+                                                <div
+                                                    key={item.id}
+                                                    style={{
+                                                        backgroundColor:
+                                                            item.colorCode,
+                                                    }}
+                                                    className='colorBox'
+                                                >
+                                                    <p>{item.colorCode}</p>
+                                                </div>
+                                            )}
+
+                                            <div className='colorName'>
+                                                <p>
+                                                    <span
+                                                        style={{
+                                                            color: 'green',
+                                                        }}
+                                                    >
+                                                        (+ R$
+                                                        {item.aditionalPrice})
+                                                    </span>{' '}
+                                                    {item.colorName}
+                                                </p>
+
+                                                <input
+                                                    type='checkbox'
+                                                    value={index}
+                                                    id={index}
+                                                    onChange={(event) =>
+                                                        checkColor(item, event)
+                                                    }
+                                                    style={{
+                                                        accentColor:
+                                                            item.colorCode,
+                                                    }}
+                                                />
+                                            </div>
+                                        </div>
+                                    ) : null
+                                ) : null
+                            )}
                         </Slider>
                     </div>
                 </div>
@@ -1193,12 +1327,30 @@ export default function Carcara() {
                                     <h2>Cor do elástico</h2>
                                 </div>
 
-                                <p>
-                                    Selecione <strong>uma</strong> cor
-                                </p>
+                                {preSelectedElasticColor ? (
+                                    <p style={{ lineHeight: '2.5rem' }}>
+                                        A capa escolhida já possui a cor do
+                                        elástico:{'  '}
+                                        <span className='emphasisWarning'>
+                                            {preSelectedElasticColor.colorName}
+                                        </span>
+                                        {'  '}
+                                        pré-definida. Avance para a próxima
+                                        etapa.
+                                    </p>
+                                ) : (
+                                    <p>
+                                        Selecione <strong>uma</strong> cor
+                                    </p>
+                                )}
                             </div>
 
-                            <div className='elasticColorWrapper'>
+                            <div
+                                className='elasticColorWrapper'
+                                style={{
+                                    display: displayElasticColorSelection,
+                                }}
+                            >
                                 {dataColors.map((item, index) =>
                                     item.models.includes('carcara') &&
                                     item.categories.includes('elastic') ? (
@@ -1325,10 +1477,7 @@ export default function Carcara() {
                                     </li>
                                 </ul>
 
-                                <h3>
-                                    Valor do sketchbook: R${' '}
-                                    {sketchbookInfos.value}
-                                </h3>
+                                <h3>Valor do sketchbook: R$ {totalValue}</h3>
 
                                 <button onClick={() => addToCart()}>
                                     Adicionar ao carrinho

--- a/src/pages/create/facheiro/index.js
+++ b/src/pages/create/facheiro/index.js
@@ -32,9 +32,16 @@ export default function Facheiro() {
     const [selectedPaperWidth, setSelectedPaperWidth] = useState('');
     const [selectedSpiralColor, setSelectedSpiralColor] = useState('');
     const [selectedElasticColor, setSelectedElasticColor] = useState('');
+    const [preSelectedSpiralColor, setPreSelectedSpiralColor] = useState('');
+    const [preSelectedElasticColor, setPreSelectedElasticColor] = useState('');
+    const [displaySpiralColorSelection, setDisplaySpiralColorSelection] =
+        useState('flex');
+    const [displayElasticColorSelection, setDisplayElasticColorSelection] =
+        useState('flex');
     const [selectedSketchFinish, setSelectedSketchFinish] = useState('');
     const [clientNote, setClientNote] = useState('');
     const [sketchbookInfos, setSketchbookInfos] = useState('');
+    const [totalValue, setTotalValue] = useState(0);
     const [displayModal, setDisplayModal] = useState('none');
     const [maxSlides, setMaxSlides] = useState(5);
     const [currentStep, setCurrentStep] = useState(1);
@@ -699,11 +706,30 @@ export default function Facheiro() {
         // forçando-o a escolher novamente o papel do miolo, garantindo que o preço e os papel escolhidos estarão corretos
         setSketchbookInfos('');
         document.querySelector('.paper').selectedIndex = 0;
+        setTotalValue(0);
     }
 
     function handleSelectedType(event) {
         let position = event.target.value;
         setSketchbookInfos(formatTypes[position]);
+        setTotalValue(formatTypes[position].value);
+
+        // desmarca todas as checkboxes
+        document
+            .querySelectorAll('input[type=checkbox]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+        //"despinta" todas as checkboxes
+        document.querySelectorAll('.coverColorLabel').forEach((label) => {
+            label.style.backgroundColor = 'transparent';
+        });
+        // zera as capas selecionadas, para nao dar problema no calculo do preco se selecionar uma capa ILUSTRES
+        setSelectedColors([]);
+        setCheckedBoxes(0);
+        // zera as cores de linha e elastico selecionadas, para caso seja selecionado uma ilustres e o cliente volte para mudar o papel, e
+        // pelas linhas acima as capas sao zeradas, e se uma capa ilustre que tinha sido selecionada é zerada, suas cores (de linha e elastico) predefinidas tambem precisam ser zeradas
+        zerarCoresPreSelecionadas();
     }
 
     function onAuthStateChanged(user) {
@@ -749,7 +775,7 @@ export default function Facheiro() {
             id: formatId,
             paperWidth: selectedPaperWidth,
             paper: sketchbookInfos.name,
-            value: sketchbookInfos.value,
+            value: totalValue,
             spiralColor: selectedSpiralColor,
             elasticColor: selectedElasticColor,
             sketchFinish: selectedSketchFinish,
@@ -799,6 +825,30 @@ export default function Facheiro() {
             ]);
 
             setCheckedBoxes(checkedBoxes + 1);
+
+            if (item.isIlustres) {
+                setTotalValue(sketchbookInfos.value + item.aditionalPrice);
+                // define a cor do sketch e esconde o seletor de cor de linha se a pre definifa existir (se nao for uma string vazia)
+                if (item.preSelectedSpiralColor) {
+                    setDisplaySpiralColorSelection('none');
+                    setSelectedSpiralColor(item.preSelectedSpiralColor);
+                    setPreSelectedSpiralColor(item.preSelectedSpiralColor);
+                }
+                // define a cor do sketch e esconde o seletor de cor de elastico se a pre definifa existir (se nao for uma string vazia)
+                if (item.preSelectedElasticColor) {
+                    setDisplayElasticColorSelection('none');
+                    setSelectedElasticColor(item.preSelectedElasticColor);
+                    setPreSelectedElasticColor(item.preSelectedElasticColor);
+                }
+
+                // desmarca todos os radio buttons de cor de elastico e o seletor de cor da espiral
+                document.querySelector('#spiralColorSelect').selectedIndex = 0;
+                document
+                    .querySelectorAll('input[name=selectedElasticColor]')
+                    .forEach(function (check) {
+                        check.checked = false;
+                    });
+            }
         } else {
             const color = item.colorName;
             let index = selectedColors.findIndex(
@@ -809,8 +859,31 @@ export default function Facheiro() {
                 selectedColors.splice(index, 1);
                 setCheckedBoxes(checkedBoxes - 1);
             }
+
+            if (item.isIlustres) {
+                setTotalValue(sketchbookInfos.value);
+                zerarCoresPreSelecionadas();
+            }
         }
     };
+
+    function zerarCoresPreSelecionadas() {
+        setSelectedSpiralColor('');
+        setPreSelectedSpiralColor('');
+        setSelectedElasticColor('');
+        setPreSelectedElasticColor('');
+
+        setDisplaySpiralColorSelection('flex');
+        setDisplayElasticColorSelection('flex');
+
+        // desmarca todos os radio buttons de cor de elastico e o seletor de cor da espiral
+        document.querySelector('#spiralColorSelect').selectedIndex = 0;
+        document
+            .querySelectorAll('input[name=selectedElasticColor]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+    }
 
     useEffect(() => {
         if (
@@ -1089,12 +1162,15 @@ export default function Facheiro() {
 
                     <div className='sliderColors'>
                         <Slider {...settings}>
+                            {/* Mostra todas as capas que nao sao ilustres, que sao deste modelo */}
                             {dataColors.map((item, index) =>
                                 item.models.includes('facheiro') &&
-                                item.categories.includes('cover') ? (
+                                item.categories.includes('cover') &&
+                                !item.isIlustres ? (
                                     <div className='cardColor' key={index}>
                                         <label
                                             htmlFor={index}
+                                            className='coverColorLabel'
                                             onClick={(event) =>
                                                 changeColor(event)
                                             }
@@ -1142,6 +1218,77 @@ export default function Facheiro() {
                                     </div>
                                 ) : null
                             )}
+                            {/* Mostra as capas ilustres ao final para deixar agrupadas, que sao deste modelo, e que estao disponiveis para o tamanho selecionado */}
+                            {dataColors.map((item, index) =>
+                                item.availableSizes && selectedPaperWidth ? (
+                                    item.models.includes('mandacaru') &&
+                                    item.categories.includes('cover') &&
+                                    item.availableSizes.includes(
+                                        selectedPaperWidth
+                                    ) ? (
+                                        <div className='cardColor' key={index}>
+                                            <label
+                                                htmlFor={index}
+                                                className='coverColorLabel'
+                                                onClick={(event) =>
+                                                    changeColor(event)
+                                                }
+                                            />
+
+                                            {item.image ? (
+                                                <div
+                                                    key={item.id}
+                                                    className='colorBox'
+                                                >
+                                                    <img
+                                                        draggable='false'
+                                                        src={item.image}
+                                                        alt='cor'
+                                                    />
+                                                </div>
+                                            ) : (
+                                                <div
+                                                    key={item.id}
+                                                    style={{
+                                                        backgroundColor:
+                                                            item.colorCode,
+                                                    }}
+                                                    className='colorBox'
+                                                >
+                                                    <p>{item.colorCode}</p>
+                                                </div>
+                                            )}
+
+                                            <div className='colorName'>
+                                                <p>
+                                                    <span
+                                                        style={{
+                                                            color: 'green',
+                                                        }}
+                                                    >
+                                                        (+ R$
+                                                        {item.aditionalPrice})
+                                                    </span>{' '}
+                                                    {item.colorName}
+                                                </p>
+
+                                                <input
+                                                    type='checkbox'
+                                                    value={index}
+                                                    id={index}
+                                                    onChange={(event) =>
+                                                        checkColor(item, event)
+                                                    }
+                                                    style={{
+                                                        accentColor:
+                                                            item.colorCode,
+                                                    }}
+                                                />
+                                            </div>
+                                        </div>
+                                    ) : null
+                                ) : null
+                            )}
                         </Slider>
                     </div>
                 </div>
@@ -1151,16 +1298,27 @@ export default function Facheiro() {
                         <div className='textBackground'>
                             <h2>Cor do espiral</h2>
                         </div>
+                        {preSelectedSpiralColor ? (
+                            <p style={{ lineHeight: '2.5rem' }}>
+                                A capa escolhida já possui a cor de espiral:
+                                {'  '}
+                                <span className='emphasisWarning'>
+                                    {preSelectedSpiralColor}
+                                </span>
+                                {'  '}
+                                pré-definida. Avance para a próxima etapa.
+                            </p>
+                        ) : null}
                     </div>
 
-                    <fieldset>
-                        <label htmlFor='paper'>
+                    <fieldset style={{ display: displaySpiralColorSelection }}>
+                        <label htmlFor='spiralColorSelect'>
                             Selecione a cor do espiral
                         </label>
 
                         <select
                             onChange={handleSelectedSpiralColor}
-                            className='paper'
+                            id='spiralColorSelect'
                             defaultValue='0'
                         >
                             <option value='0' disabled>
@@ -1180,14 +1338,32 @@ export default function Facheiro() {
                                     <h2>Cor do elástico</h2>
                                 </div>
 
-                                <p>
-                                    Selecione <strong>uma</strong> cor
-                                </p>
+                                {preSelectedElasticColor ? (
+                                    <p style={{ lineHeight: '2.5rem' }}>
+                                        A capa escolhida já possui a cor do
+                                        elástico:{'  '}
+                                        <span className='emphasisWarning'>
+                                            {preSelectedElasticColor.colorName}
+                                        </span>
+                                        {'  '}
+                                        pré-definida. Avance para a próxima
+                                        etapa.
+                                    </p>
+                                ) : (
+                                    <p>
+                                        Selecione <strong>uma</strong> cor
+                                    </p>
+                                )}
                             </div>
 
-                            <div className='elasticColorWrapper'>
+                            <div
+                                className='elasticColorWrapper'
+                                style={{
+                                    display: displayElasticColorSelection,
+                                }}
+                            >
                                 {dataColors.map((item, index) =>
-                                    item.models.includes('buriti') &&
+                                    item.models.includes('facheiro') &&
                                     item.categories.includes('elastic') ? (
                                         <div
                                             className='colorWrapper'
@@ -1320,10 +1496,7 @@ export default function Facheiro() {
                                     </li>
                                 </ul>
 
-                                <h3>
-                                    Valor do sketchbook: R${' '}
-                                    {sketchbookInfos.value}
-                                </h3>
+                                <h3>Valor do sketchbook: R$ {totalValue}</h3>
 
                                 <button onClick={() => addToCart()}>
                                     Adicionar ao carrinho

--- a/src/pages/create/mandacaru/index.js
+++ b/src/pages/create/mandacaru/index.js
@@ -31,8 +31,15 @@ export default function Mandacaru() {
     const [selectedPaperWidth, setSelectedPaperWidth] = useState('');
     const [selectedLineColor, setSelectedLineColor] = useState('');
     const [selectedElasticColor, setSelectedElasticColor] = useState('');
+    const [preSelectedLineColor, setPreSelectedLineColor] = useState('');
+    const [preSelectedElasticColor, setPreSelectedElasticColor] = useState('');
+    const [displayLineColorSelection, setDisplayLineColorSelection] =
+        useState('flex');
+    const [displayElasticColorSelection, setDisplayElasticColorSelection] =
+        useState('flex');
     const [clientNote, setClientNote] = useState('');
     const [sketchbookInfos, setSketchbookInfos] = useState('');
+    const [totalValue, setTotalValue] = useState(0);
     const [displayModal, setDisplayModal] = useState('none');
     const [maxSlides, setMaxSlides] = useState(5);
     const [currentStep, setCurrentStep] = useState(1);
@@ -599,11 +606,30 @@ export default function Mandacaru() {
         // forçando-o a escolher novamente o papel do miolo, garantindo que o preço e o papel escolhidos estarão corretos
         setSketchbookInfos('');
         document.querySelector('.paper').selectedIndex = 0;
+        setTotalValue(0);
     }
 
     function handleSelectedType(event) {
         let position = event.target.value;
         setSketchbookInfos(formatTypes[position]);
+        setTotalValue(formatTypes[position].value);
+
+        // desmarca todas as checkboxes
+        document
+            .querySelectorAll('input[type=checkbox]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+        //"despinta" todas as checkboxes
+        document.querySelectorAll('.coverColorLabel').forEach((label) => {
+            label.style.backgroundColor = 'transparent';
+        });
+        // zera as capas selecionadas, para nao dar problema no calculo do preco se selecionar uma capa ILUSTRES
+        setSelectedColors([]);
+        setCheckedBoxes(0);
+        // zera as cores de linha e elastico selecionadas, para caso seja selecionado uma ilustres e o cliente volte para mudar o papel, e
+        // pelas linhas acima as capas sao zeradas, e se uma capa ilustre que tinha sido selecionada é zerada, suas cores (de linha e elastico) predefinidas tambem precisam ser zeradas
+        zerarCoresPreSelecionadas();
     }
 
     function onAuthStateChanged(user) {
@@ -649,7 +675,7 @@ export default function Mandacaru() {
             id: formatId,
             paperWidth: selectedPaperWidth,
             paper: sketchbookInfos.name,
-            value: sketchbookInfos.value,
+            value: totalValue,
             lineColor: selectedLineColor,
             elasticColor: selectedElasticColor,
             sketchFinish: selectedSketchFinish,
@@ -699,6 +725,36 @@ export default function Mandacaru() {
             ]);
 
             setCheckedBoxes(checkedBoxes + 1);
+
+            if (item.isIlustres) {
+                setTotalValue(sketchbookInfos.value + item.aditionalPrice);
+
+                // define a cor do sketch e esconde o seletor de cor de linha se a pre definifa existir (se nao for uma string vazia)
+                if (item.preSelectedLineColor) {
+                    setDisplayLineColorSelection('none');
+                    setSelectedLineColor(item.preSelectedLineColor);
+                    setPreSelectedLineColor(item.preSelectedLineColor);
+                }
+
+                // define a cor do sketch e esconde o seletor de cor de elastico se a pre definifa existir (se nao for uma string vazia)
+                if (item.preSelectedElasticColor) {
+                    setDisplayElasticColorSelection('none');
+                    setSelectedElasticColor(item.preSelectedElasticColor);
+                    setPreSelectedElasticColor(item.preSelectedElasticColor);
+                }
+
+                // desmarca todos os radio buttons de cor de linha e cor de elastico
+                document
+                    .querySelectorAll('input[name=selectedLineColor]')
+                    .forEach(function (check) {
+                        check.checked = false;
+                    });
+                document
+                    .querySelectorAll('input[name=selectedElasticColor]')
+                    .forEach(function (check) {
+                        check.checked = false;
+                    });
+            }
         } else {
             const color = item.colorName;
             let index = selectedColors.findIndex(
@@ -709,8 +765,35 @@ export default function Mandacaru() {
                 selectedColors.splice(index, 1);
                 setCheckedBoxes(checkedBoxes - 1);
             }
+
+            if (item.isIlustres) {
+                setTotalValue(sketchbookInfos.value);
+                zerarCoresPreSelecionadas();
+            }
         }
     };
+
+    function zerarCoresPreSelecionadas() {
+        setSelectedLineColor('');
+        setPreSelectedLineColor('');
+        setSelectedElasticColor('');
+        setPreSelectedElasticColor('');
+
+        setDisplayLineColorSelection('flex');
+        setDisplayElasticColorSelection('flex');
+
+        // desmarca todos os radio buttons de cor de linha e cor de elastico
+        document
+            .querySelectorAll('input[name=selectedLineColor]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+        document
+            .querySelectorAll('input[name=selectedElasticColor]')
+            .forEach(function (check) {
+                check.checked = false;
+            });
+    }
 
     useEffect(() => {
         if (
@@ -980,12 +1063,15 @@ export default function Mandacaru() {
 
                     <div className='sliderColors'>
                         <Slider {...settings}>
+                            {/* Mostra todas as capas que nao sao ilustres, que sao deste modelo */}
                             {dataColors.map((item, index) =>
                                 item.models.includes('mandacaru') &&
-                                item.categories.includes('cover') ? (
+                                item.categories.includes('cover') &&
+                                !item.isIlustres ? (
                                     <div className='cardColor' key={index}>
                                         <label
                                             htmlFor={index}
+                                            className='coverColorLabel'
                                             onClick={(event) =>
                                                 changeColor(event)
                                             }
@@ -1033,6 +1119,77 @@ export default function Mandacaru() {
                                     </div>
                                 ) : null
                             )}
+                            {/* Mostra as capas ilustres ao final para deixar agrupadas, que sao deste modelo, e que estao disponiveis para o tamanho selecionado */}
+                            {dataColors.map((item, index) =>
+                                item.availableSizes && selectedPaperWidth ? (
+                                    item.models.includes('mandacaru') &&
+                                    item.categories.includes('cover') &&
+                                    item.availableSizes.includes(
+                                        selectedPaperWidth
+                                    ) ? (
+                                        <div className='cardColor' key={index}>
+                                            <label
+                                                htmlFor={index}
+                                                className='coverColorLabel'
+                                                onClick={(event) =>
+                                                    changeColor(event)
+                                                }
+                                            />
+
+                                            {item.image ? (
+                                                <div
+                                                    key={item.id}
+                                                    className='colorBox'
+                                                >
+                                                    <img
+                                                        draggable='false'
+                                                        src={item.image}
+                                                        alt='cor'
+                                                    />
+                                                </div>
+                                            ) : (
+                                                <div
+                                                    key={item.id}
+                                                    style={{
+                                                        backgroundColor:
+                                                            item.colorCode,
+                                                    }}
+                                                    className='colorBox'
+                                                >
+                                                    <p>{item.colorCode}</p>
+                                                </div>
+                                            )}
+
+                                            <div className='colorName'>
+                                                <p>
+                                                    <span
+                                                        style={{
+                                                            color: 'green',
+                                                        }}
+                                                    >
+                                                        (+ R$
+                                                        {item.aditionalPrice})
+                                                    </span>{' '}
+                                                    {item.colorName}
+                                                </p>
+
+                                                <input
+                                                    type='checkbox'
+                                                    value={index}
+                                                    id={index}
+                                                    onChange={(event) =>
+                                                        checkColor(item, event)
+                                                    }
+                                                    style={{
+                                                        accentColor:
+                                                            item.colorCode,
+                                                    }}
+                                                />
+                                            </div>
+                                        </div>
+                                    ) : null
+                                ) : null
+                            )}
                         </Slider>
                     </div>
                 </div>
@@ -1045,12 +1202,29 @@ export default function Mandacaru() {
                                     <h2>Cor da linha</h2>
                                 </div>
 
-                                <p>
-                                    Selecione <strong>uma</strong> cor
-                                </p>
+                                {preSelectedLineColor ? (
+                                    <p style={{ lineHeight: '2.5rem' }}>
+                                        A capa escolhida já possui a cor de
+                                        linha:
+                                        {'  '}
+                                        <span className='emphasisWarning'>
+                                            {preSelectedLineColor.colorName}
+                                        </span>
+                                        {'  '}
+                                        pré-definida. Avance para a próxima
+                                        etapa.
+                                    </p>
+                                ) : (
+                                    <p>
+                                        Selecione <strong>uma</strong> cor
+                                    </p>
+                                )}
                             </div>
 
-                            <div className='lineColorWrapper'>
+                            <div
+                                className='lineColorWrapper'
+                                style={{ display: displayLineColorSelection }}
+                            >
                                 {dataColors.map((item, index) =>
                                     item.models.includes('mandacaru') &&
                                     item.categories.includes('line') ? (
@@ -1108,12 +1282,30 @@ export default function Mandacaru() {
                                     <h2>Cor do elástico</h2>
                                 </div>
 
-                                <p>
-                                    Selecione <strong>uma</strong> cor
-                                </p>
+                                {preSelectedElasticColor ? (
+                                    <p style={{ lineHeight: '2.5rem' }}>
+                                        A capa escolhida já possui a cor do
+                                        elástico:{'  '}
+                                        <span className='emphasisWarning'>
+                                            {preSelectedElasticColor.colorName}
+                                        </span>
+                                        {'  '}
+                                        pré-definida. Avance para a próxima
+                                        etapa.
+                                    </p>
+                                ) : (
+                                    <p>
+                                        Selecione <strong>uma</strong> cor
+                                    </p>
+                                )}
                             </div>
 
-                            <div className='elasticColorWrapper'>
+                            <div
+                                className='elasticColorWrapper'
+                                style={{
+                                    display: displayElasticColorSelection,
+                                }}
+                            >
                                 {dataColors.map((item, index) =>
                                     item.models.includes('mandacaru') &&
                                     item.categories.includes('elastic') ? (
@@ -1248,10 +1440,7 @@ export default function Mandacaru() {
                                     </li>
                                 </ul>
 
-                                <h3>
-                                    Valor do sketchbook: R${' '}
-                                    {sketchbookInfos.value}
-                                </h3>
+                                <h3>Valor do sketchbook: R$ {totalValue}</h3>
 
                                 <button onClick={() => addToCart()}>
                                     Adicionar ao carrinho

--- a/src/pages/create/mescla/index.js
+++ b/src/pages/create/mescla/index.js
@@ -845,7 +845,9 @@ export default function Mescla() {
                                                 .normalize('NFD')
                                                 .replace(/[\u0300-\u036f]/g, '')
                                         ) &&
-                                        item.categories.includes('cover') ? (
+                                        item.categories.includes('cover') &&
+                                        //nao mostra as capas ilustres pq nao estao disponiveis no mescla
+                                        !item.isIlustres ? (
                                             <div
                                                 className='cardColor'
                                                 key={index}

--- a/src/pages/create/sertao/index.js
+++ b/src/pages/create/sertao/index.js
@@ -792,7 +792,9 @@ export default function Sertao() {
                         <Slider {...settings}>
                             {dataColors.map((item, index) =>
                                 item.models.includes('sertao') &&
-                                item.categories.includes('cover') ? (
+                                item.categories.includes('cover') &&
+                                // não mostra as capas ilustres, caso seja cadastrada errado, pq nao esta disponivel pro sertao
+                                !item.isIlustres ? (
                                     <div className='cardColor' key={index}>
                                         <label
                                             htmlFor={index}


### PR DESCRIPTION
Adicao das capas ilustre que só podem ser selecionadas em certos modelos e em certos tamanhos, e que adicionam um valor no preço e já tem cores de elastico, linha e espiral pré-definidas.

Mudanças feitas: 
- Cadastro de "cor" Ilustres com adicao de valor, cadastro de cores de elastico, linha e espiral pré-definidas, e tamanho disponível.

- Mostragem do valor adicional nas labels das capas

- Nas paginas dos sketchbooks que podem ter a capa ilustres, mostra as capas e calcula o preço adicional, nas páginas dos que não podem ter as capas ilustres, as capas ilustres não são mostradas.

- fix: mostragem de cores de elastico do facheiro consertada

- Altura do Slider de cor da capa aumentada para melhorar a vista das capas